### PR TITLE
Fix where singularity build ends up with empty parameter

### DIFF
--- a/bactopia/cli/download.py
+++ b/bactopia/cli/download.py
@@ -315,7 +315,7 @@ def build_singularity_image(
     singularity_exe="singularity",
 ):
     """Build Conda env, with chance to retry."""
-    force = "--force " if force else ""
+    force = "--force" if force else ""
     retry = 0
     allow_fail = False
     success = False
@@ -323,7 +323,7 @@ def build_singularity_image(
         result = None
         if use_build:
             result = execute(
-                f"{singularity_exe} build {force}{image} {pull}", allow_fail=allow_fail
+                f"{singularity_exe} build {force} {image} {pull}", allow_fail=allow_fail
             )
         else:
             # Download from Galaxy Project

--- a/bactopia/cli/download.py
+++ b/bactopia/cli/download.py
@@ -315,7 +315,7 @@ def build_singularity_image(
     singularity_exe="singularity",
 ):
     """Build Conda env, with chance to retry."""
-    force = "--force" if force else ""
+    force = "--force " if force else ""
     retry = 0
     allow_fail = False
     success = False
@@ -323,7 +323,7 @@ def build_singularity_image(
         result = None
         if use_build:
             result = execute(
-                f"{singularity_exe} build {force} {image} {pull}", allow_fail=allow_fail
+                f"{singularity_exe} build {force}{image} {pull}", allow_fail=allow_fail
             )
         else:
             # Download from Galaxy Project

--- a/bactopia/utils.py
+++ b/bactopia/utils.py
@@ -49,6 +49,8 @@ def execute(
         else:
             return command.returncode
     except subprocess.CalledProcessError as e:
+        logging.debug(f"STDOUT: \n{command.stdout}")
+        logging.debug(f"STDERR:\n{command.stderr}")        
         if allow_fail:
             logging.debug(f'"{cmd}" return exit code {e.returncode}')
             logging.debug(e)

--- a/bactopia/utils.py
+++ b/bactopia/utils.py
@@ -49,17 +49,18 @@ def execute(
         else:
             return command.returncode
     except subprocess.CalledProcessError as e:
-        logging.debug(f"STDOUT: \n{command.stdout}")
-        logging.debug(f"STDERR:\n{command.stderr}")        
         if allow_fail:
-            logging.debug(f'"{cmd}" return exit code {e.returncode}')
-            logging.debug(e)
+            logger = logging.debug
+        else:
+            logger = logging.error
+        logger(f"STDOUT: \n{e.stdout}")
+        logger(f"STDERR:\n{e.stderr}")        
+        logger(f'"{cmd}" return exit code {e.returncode}')
+        logger(e)
+        if allow_fail:
             return None
         else:
-            logging.error(f'"{cmd}" return exit code {e.returncode}')
-            logging.error(e)
             sys.exit(e.returncode)
-
 
 def pgzip(files: list, cpus: int) -> list:
     """

--- a/bactopia/utils.py
+++ b/bactopia/utils.py
@@ -1,4 +1,5 @@
 import logging
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -33,7 +34,7 @@ def execute(
     logging.debug(f"Working directory: {directory}")
     try:
         command = subprocess.run(
-            cmd.split(" "),  # Replace with your command and arguments
+            shlex.split(cmd),  # Replace with your command and arguments
             cwd=directory,
             capture_output=True,
             text=True,  # Decodes stdout/stderr as strings using default encoding


### PR DESCRIPTION
The [current code](https://github.com/bactopia/bactopia-py/blob/main/bactopia/cli/download.py#L318) yields this command:

```
ERROR    Command '['singularity', 'build', '',                                           utils.py:57
                             '[PATH]/quay.io-biocontainers-csvtk-0.31.0--h9ee0642_0.img'
                             , 'docker://quay.io/biocontainers/csvtk:0.31.0--h9ee0642_0']' returned non-zero
                             exit status 1.
```

This PR does two things:

1. It uses `shlex.split` rather than `string.split` to avoid the above-mentioned problem
2. It produces output event if the command fails (current code raises an exception before producing output)